### PR TITLE
Revert "Update URL to docs for altinity-clickhouse-operator"

### DIFF
--- a/platform-applications/altinity-clickhouse-operator.yaml
+++ b/platform-applications/altinity-clickhouse-operator.yaml
@@ -7,7 +7,7 @@ spec:
   project: platform
   source:
     chart: altinity-clickhouse-operator
-    repoURL: https://docs.altinity.com/altinitykubernetesoperator/
+    repoURL: https://docs.altinity.com/clickhouse-operator/
     targetRevision: 0.21.0
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
Reverts reclaim-the-stack/get-started#1

I just assume this was a fix for an incorrect URL. But this was in fact the correct Helm repository URL (ie. try running `helm repo add test https://docs.altinity.com/clickhouse-operator` and that should work).