### PR TITLE
chore: update config format to fix deprecation warning

### DIFF
--- a/platform/argocd/kustomization.yaml
+++ b/platform/argocd/kustomization.yaml
@@ -1,10 +1,11 @@
 namespace: argocd
 resources:
-  - ./namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.11.3/manifests/install.yaml
+- ./namespace.yaml
+- https://raw.githubusercontent.com/argoproj/argo-cd/v2.11.3/manifests/install.yaml
 
 # NOTE: patchesStrategicMerge is deprecated but still works. Converting to the suggested
 # patches: { file: ./config.yaml } syntax results in a validation error.
-patchesStrategicMerge:
-  - ./config.yaml
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: ./config.yaml


### PR DESCRIPTION
First heard out about reclaim-the-stack at BalticRuby. Thank you for making this.

Saw the patchesStrategicMerge deprecation warning and did: 
$ cd platform/argocd/
$ kustomize edit fix
$ cd -

Read the note/comment, could the noted validation error be because of file: vs path: ?
I tried to edit using file: as in the note, and got error: invalid Kustomization, but the automated kustomize edit fix is without warnings.

Tested creating/deleting resources:
$ kubectl create -k platform/argocd
$ kubectl delete -k platform/argocd

No warning for me anymore using:
$ kustomize version
v5.4.3
$ kubectl version
Client Version: v1.31.1
Kustomize Version: v5.4.2
Server Version: v1.31.1
