### PR TITLE
Postgres and Redis upgrades validated on a live test cluster

### DIFF
--- a/agent/VERIFICATION.md
+++ b/agent/VERIFICATION.md
@@ -3,6 +3,19 @@
 Checks and pitfalls discovered during test runs, beyond what smoke-test.sh
 covers. Append to this file when a run teaches you something the checks missed.
 
+## Run 36df1f (2026-07-20, second run; cluster kept for operator upgrade testing)
+
+- **`rails-example:latest` is a moving target.** The image was rebuilt between
+  two same-day runs (Sidekiq 7 -> 8), and Sidekiq 8 requires Redis 7+ while the
+  spotahome operator defaults to redis:6.2.6-alpine when the RedisFailover
+  spec has no image -- sidekiq crashlooped with "Sidekiq requires Redis 7.0.0
+  or greater". Fixed by pinning redis:7.4.9-alpine (redis + sentinel) in the
+  redis generator. When a deployment behaves differently between runs, check
+  whether the image tag moved (Docker Hub API shows `last_updated`).
+- Platform bootstrap + tunnel + smoke test needed zero manual intervention
+  this run — all run-0d0024 fixes (sealed-secrets URL, explicit DNS records,
+  ES quantity quoting, K_CONTEXT procedure) validated from scratch.
+
 ## Run 0d0024 (2026-07-20, first end-to-end run)
 
 - **Root/parent ArgoCD apps can be Healthy while a child app is broken.**

--- a/agent/VERIFICATION.md
+++ b/agent/VERIFICATION.md
@@ -3,6 +3,25 @@
 Checks and pitfalls discovered during test runs, beyond what smoke-test.sh
 covers. Append to this file when a run teaches you something the checks missed.
 
+## Run 36df1f upgrade phase (2026-07-20, CNPG 1.26.0 -> 1.30.0, PG 17.5 -> 18.4)
+
+- **CNPG operator upgrade restarts every instance.** The 1.26 -> 1.30 jump
+  rolled the instance managers: replicas restarted first, then the primary
+  in-place ("Primary instance is being restarted without a switchover",
+  ~3.5 min with a brief write-unavailability window). Total ~4 min back to
+  healthy; data and app unaffected. Expect this on any operator bump.
+- **Declarative PG major upgrades work and are fast on small data.**
+  Changing imageName 17.5 -> 18.4 triggered CNPG's offline pg_upgrade path:
+  "Upgrading Postgres major version" (~4 min, cluster offline), primary up,
+  replica re-cloned, healthy at ~4.5 min. Data verified intact afterwards.
+  Watch `.status.phase` on the Cluster resource for the timeline.
+- **Switching enablePodMonitor -> explicit PodMonitor loses the monitor once.**
+  The operator deletes its auto-managed PodMonitor when the flag goes away,
+  taking the identically-named ArgoCD-created one with it; without selfHeal
+  the app then sits OutOfSync (Healthy). One manual sync fixes it — trigger
+  headless with:
+  `kubectl patch application <app> -n argocd --type merge -p '{"operation":{"sync":{"revision":"<branch>"}}}'`
+
 ## Run 36df1f (2026-07-20, second run; cluster kept for operator upgrade testing)
 
 - **`rails-example:latest` is a moving target.** The image was rebuilt between

--- a/generators/resources/postgres.yaml
+++ b/generators/resources/postgres.yaml
@@ -21,8 +21,6 @@
 #       work_mem: 3276kB
 #       min_wal_size: 1GB
 #       max_wal_size: 4GB
-#       pg_stat_statements.max: "10000"
-#       pg_stat_statements.track: top
 # env:
 #   - { name: DATABASE_URL, valueFrom: { secretKeyRef: { name: %{application}%{suffix}-app, key: uri } } }
 
@@ -31,7 +29,7 @@ kind: Cluster
 metadata:
   name: {{ .Chart.Name }}%{suffix}
 spec:
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4
   primaryUpdateStrategy: unsupervised
   enableSuperuserAccess: false
   instances: {{ .Values.resources.%{camelName}.replicas }}
@@ -41,7 +39,8 @@ spec:
       cpu: {{ .Values.resources.%{camelName}.cpu | quote }}
     limits:
       memory: {{ .Values.resources.%{camelName}.memory }}
-      cpu: {{ .Values.resources.%{camelName}.cpu | quote }}
+      # NOTE: no cpu limit to avoid throttling, see https://home.robusta.dev/blog/stop-using-cpu-limits
+      # cpu: {{ .Values.resources.%{camelName}.cpu | quote }}
   storage:
     size: {{ .Values.resources.%{camelName}.disk }}
   bootstrap:
@@ -54,10 +53,9 @@ spec:
         - ALTER ROLE "{{ .Chart.Name }}" WITH REPLICATION;
         - GRANT pg_create_subscription TO "{{ .Chart.Name }}";
   postgresql:
-    parameters:
-      {{ .Values.resources.%{camelName}.config | toYaml | nindent 6 }}
-  monitoring:
-    enablePodMonitor: true
+    parameters: {{ .Values.resources.%{camelName}.config | toYaml | nindent 6 }}
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
   affinity:
     tolerations:
       - key: role
@@ -69,24 +67,48 @@ spec:
           - matchExpressions:
               - key: node-role.kubernetes.io/database
                 operator: Exists
-# The following example uses S3-compatible storage for backups. Refer to the CloudnativePG
-# documentation for more details and options like Azure and Google Cloud Storage.
-#   backup:
-#     retentionPolicy: 30d
-#     barmanObjectStore:
-#       destinationPath: s3://<bucket-name>/cloudnativepg
-#       # endpointURL: https://<s3-compatible-host> # for non-AWS S3-compatible storage
-#       # Prepare this secret with: k secrets:create cloudnativepg-s3-credentials
-#       s3Credentials:
-#         accessKeyId:
-#           name: cloudnativepg-s3-credentials
-#           key: ACCESS_KEY_ID
-#         secretAccessKey:
-#           name: cloudnativepg-s3-credentials
-#           key: SECRET_ACCESS_KEY
-#       wal:
-#         compression: gzip
-#         maxParallel: 4
+# Uncomment the managed block and generate a sealed secret for the passwordSecret to enable readonly user
+#   managed:
+#     roles:
+#       - name: readonly
+#         login: true
+#         replication: true
+#         inRoles:
+#           - pg_read_all_data
+#           - pg_read_all_settings
+#           - pg_read_all_stats
+#         passwordSecret:
+#           name: {{ .Chart.Name }}-readonly
+# Uncomment the plugins block, ObjectStore resource, and ScheduledBackup resource to enable
+# WAL archiving and scheduled backups via the CNPG-I Barman Cloud Plugin (CloudNativePG 1.28+).
+# The plugin must be installed in the cluster first, see:
+# https://github.com/cloudnative-pg/plugin-barman-cloud
+#   plugins:
+#     - name: barman-cloud.cloudnative-pg.io
+#       isWALArchiver: true
+#       parameters:
+#         barmanObjectName: {{ .Chart.Name }}%{suffix}
+# ---
+# apiVersion: barmancloud.cnpg.io/v1
+# kind: ObjectStore
+# metadata:
+#   name: {{ .Chart.Name }}%{suffix}
+# spec:
+#   configuration:
+#     destinationPath: s3://<your-backup-bucket>/cloudnativepg
+#     # endpointURL: https://<your-s3-endpoint> # for non-AWS S3-compatible storage
+#     # Prepare this secret with: k secrets:create cloudnativepg-s3-credentials
+#     s3Credentials:
+#       accessKeyId:
+#         name: cloudnativepg-s3-credentials
+#         key: AWS_ACCESS_KEY_ID
+#       secretAccessKey:
+#         name: cloudnativepg-s3-credentials
+#         key: AWS_SECRET_ACCESS_KEY
+#     wal:
+#       compression: gzip
+#       maxParallel: 4
+#   retentionPolicy: 30d
 # ---
 # apiVersion: postgresql.cnpg.io/v1
 # kind: ScheduledBackup
@@ -97,3 +119,29 @@ spec:
 #   backupOwnerReference: self
 #   cluster:
 #     name: {{ .Chart.Name }}%{suffix}
+#   method: plugin
+#   pluginConfiguration:
+#     name: barman-cloud.cloudnative-pg.io
+# ---
+# CAUTION: Deploy the ObjectStore before deploying the initial backup or it may fail due to missing the plugin.
+# apiVersion: postgresql.cnpg.io/v1
+# kind: Backup
+# metadata:
+#   name: {{ .Chart.Name }}%{suffix}-initial
+# spec:
+#   cluster:
+#     name: {{ .Chart.Name }}%{suffix}
+#   method: plugin
+#   pluginConfiguration:
+#     name: barman-cloud.cloudnative-pg.io
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Chart.Name }}%{suffix}
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: {{ .Chart.Name }}%{suffix}
+  podMetricsEndpoints:
+    - port: metrics

--- a/generators/resources/redis.yaml
+++ b/generators/resources/redis.yaml
@@ -24,6 +24,7 @@ metadata:
   name: {{ .Chart.Name }}%{suffix}
 spec:
   sentinel:
+    image: redis:7.4.9-alpine
     replicas: {{ .Values.resources.%{camelName}.sentinels }}
     resources:
       requests:
@@ -41,6 +42,7 @@ spec:
           cpu: 200m
           memory: 100Mi
   redis:
+    image: redis:7.4.9-alpine
     replicas: {{ .Values.resources.%{camelName}.replicas }}
     # NOTE: We use native Redis maxmemory instead of Kubernetes resource limits to avoid OOM kills
     {{- $maxmemory := .Values.resources.%{camelName}.memory }}

--- a/platform/cloudnativepg/kustomization.yaml
+++ b/platform/cloudnativepg/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
   - name: cloudnative-pg
     repo: https://cloudnative-pg.github.io/charts
     releaseName: cloudnative-pg
-    version: 0.24.0 # CloudnativePG version 1.26.0
+    version: 0.29.0 # CloudnativePG version 1.30.0
     namespace: cnpg-system
     valuesInline:
       monitoring:


### PR DESCRIPTION
Component upgrades produced and verified by automated test run `36df1f` (7-node Hetzner cluster, full platform + rails-example exercising Postgres/Redis/Elasticsearch through a Cloudflare tunnel).

## Changes

### CloudNativePG operator 1.26.0 → 1.30.0 (chart 0.24.0 → 0.29.0)
- Includes the `search_path` privilege-escalation fix (GHSA-x8c2-3p4r-v9r6), primary election via Lease, and the DatabaseRole CRD.
- **Verified in-place**: the new operator rolls every instance manager — replicas first, then the primary in-place (~3.5 min phase with a brief write-unavailability window). Cluster healthy again ~4 min after sync; data and app unaffected.

### Postgres generator modernization
- `imageName` → `ghcr.io/cloudnative-pg/postgresql:18.4`. **Verified as a live major upgrade**: changing imageName on the deployed 17.5 cluster triggered CNPG's declarative offline `pg_upgrade` — ~4.5 min total (upgrade job → primary up → replica re-cloned), data verified intact.
- Backup example migrated from the deprecated in-tree `barmanObjectStore` to the CNPG-I Barman Cloud Plugin (`ObjectStore` + `method: plugin`) ahead of in-tree removal in CloudNativePG 1.31.
- CPU limit dropped (request kept) to avoid throttling.
- Commented example for a managed `readonly` role.
- `monitoring.enablePodMonitor` replaced with an explicit `PodMonitor`. Note for existing clusters: the operator deletes its auto-managed PodMonitor when the flag is removed, which also removes the identically-named new one — a single manual sync restores it (documented in VERIFICATION.md).
- `pg_stat_statements` parameters now set by the template (`track: all`) instead of the values example.

### Redis generator: pin redis:7.4.9-alpine
- The spotahome operator defaults to `redis:6.2.6-alpine` when the RedisFailover spec has no image. Current rails-example builds ship Sidekiq 8, which requires Redis 7+ and crashloops against the default ("Sidekiq requires Redis 7.0.0 or greater").
- **Verified**: operator rolled redis + sentinel pods to 7.4.9 in-place; sidekiq recovered; background jobs green.

### VERIFICATION.md
- Test-run learnings from the runs above (upgrade timelines, PodMonitor transition gotcha, moving `latest` image tags).

## Evidence
Post-upgrade state on the test cluster: PG 18.4, CNPG 1.30.0, Redis 7.4.9, all ArgoCD apps Synced/Healthy, end-to-end app checks green (post creation → Postgres, async link resolution → Redis+Sidekiq, search → Elasticsearch), data continuity verified across both upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)