### PR TITLE
Component upgrade batch: nine platform components validated on a live cluster

### DIFF
--- a/agent/VERIFICATION.md
+++ b/agent/VERIFICATION.md
@@ -3,6 +3,40 @@
 Checks and pitfalls discovered during test runs, beyond what smoke-test.sh
 covers. Append to this file when a run teaches you something the checks missed.
 
+## Run 36df1f upgrade batch 2 (2026-07-20, nine components)
+
+- **altinity-clickhouse-operator chart 0.25+ CRD hooks break under ArgoCD.**
+  The chart installs CRDs via PreSync hook ConfigMaps + a job; ArgoCD applies
+  hooks client-side (app-level ServerSideApply does NOT cover hooks) and the
+  CRD ConfigMaps exceed the 262KB annotation limit, wedging the sync on
+  "waiting for completion of hook". Fix: `crdHook.enabled: false` (CRDs are
+  already managed via helm template --include-crds) + ServerSideApply for the
+  big CRDs themselves.
+- **SSA can't switch a Deployment to `strategy: Recreate`** when the live
+  object has a defaulted rollingUpdate block ("Forbidden: may not be
+  specified"). Patch the live strategy first (remove rollingUpdate, set type)
+  or delete the deployment and let ArgoCD recreate it.
+- **Check stale upgrade-blocker comments against the upstream issue.** The
+  altinity manifest said "not upgrading until #1714" — that issue was fixed
+  in 0.25.1, a year before this run.
+- **Self-managed ArgoCD upgrades need SSA for the ApplicationSet CRD**
+  (also >262KB). And on ArgoCD 3.4.x, triggering a sync by patching
+  `.operation` does NOT inherit `spec.syncPolicy.syncOptions` — pass them
+  explicitly: `{"operation":{"sync":{"syncOptions":["ServerSideApply=true"]}}}`.
+- **Application manifests propagate via the `platform` app.** Changing
+  anything under platform-applications/ requires refreshing `platform` first,
+  then the target app. A watcher asserting only Synced/Healthy can pass
+  against the STALE spec — assert the new targetRevision/image too (this
+  batch's ECK watcher initially "passed" with the old operator running).
+  Also: app names don't always match file names (file
+  elastic-cloud-on-kubernetes.yaml -> app elastic-cloud-kubernetes-operator).
+- **Single-replica ClickHouse restarts briefly break gigapipe ingestion**
+  (transient "no such host" on the headless service during pod roll;
+  self-heals in <30s). HA would need replicas 2+ plus keeper.
+- kube-prometheus-stack 74 -> 87 (13 chart majors) applied cleanly in one
+  sync thanks to pre-existing ServerSideApply; Prometheus 3.13.1, 44 targets
+  up afterwards. ECK 3.0 -> 3.4.1 rolled in ~30s with ES green throughout.
+
 ## Run 36df1f upgrade phase (2026-07-20, CNPG 1.26.0 -> 1.30.0, PG 17.5 -> 18.4)
 
 - **CNPG operator upgrade restarts every instance.** The 1.26 -> 1.30 jump

--- a/platform-applications/altinity-clickhouse-operator.yaml
+++ b/platform-applications/altinity-clickhouse-operator.yaml
@@ -9,7 +9,7 @@ spec:
     chart: altinity-clickhouse-operator
     repoURL: https://docs.altinity.com/clickhouse-operator/
     # NOTE: Not upgrading until https://github.com/Altinity/clickhouse-operator/issues/1714 is resolved
-    targetRevision: 0.24.0
+    targetRevision: 0.27.1
   destination:
     server: https://kubernetes.default.svc
     namespace: kube-system

--- a/platform-applications/altinity-clickhouse-operator.yaml
+++ b/platform-applications/altinity-clickhouse-operator.yaml
@@ -8,7 +8,6 @@ spec:
   source:
     chart: altinity-clickhouse-operator
     repoURL: https://docs.altinity.com/clickhouse-operator/
-    # NOTE: Not upgrading until https://github.com/Altinity/clickhouse-operator/issues/1714 is resolved
     targetRevision: 0.27.1
   destination:
     server: https://kubernetes.default.svc
@@ -16,3 +15,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+    syncOptions:
+      # Required since chart 0.25+: CRDs ship via PreSync hook ConfigMaps that
+      # exceed the 262KB client-side-apply annotation limit
+      - ServerSideApply=true

--- a/platform-applications/altinity-clickhouse-operator.yaml
+++ b/platform-applications/altinity-clickhouse-operator.yaml
@@ -9,6 +9,14 @@ spec:
     chart: altinity-clickhouse-operator
     repoURL: https://docs.altinity.com/clickhouse-operator/
     targetRevision: 0.27.1
+    helm:
+      parameters:
+        # The hook-based CRD install job is redundant under ArgoCD (CRDs from
+        # the chart's crds/ dir are already rendered and managed as resources)
+        # and its ConfigMaps exceed the 262KB annotation limit ArgoCD applies
+        # hooks with
+        - name: crdHook.enabled
+          value: "false"
   destination:
     server: https://kubernetes.default.svc
     namespace: kube-system

--- a/platform-applications/argocd.yaml
+++ b/platform-applications/argocd.yaml
@@ -21,3 +21,7 @@ spec:
     automated:
       allowEmpty: true
       prune: true
+    syncOptions:
+      # The ApplicationSet CRD exceeds the 262KB last-applied annotation
+      # limit under client-side apply
+      - ServerSideApply=true

--- a/platform-applications/cert-manager.yaml
+++ b/platform-applications/cert-manager.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: cert-manager
     repoURL: https://charts.jetstack.io
-    targetRevision: 1.18.0
+    targetRevision: v1.21.0
     helm:
       parameters:
         - name: installCRDs

--- a/platform-applications/elastic-cloud-on-kubernetes.yaml
+++ b/platform-applications/elastic-cloud-on-kubernetes.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     chart: eck-operator
     repoURL: https://helm.elastic.co
-    targetRevision: 3.0.0
+    targetRevision: 3.4.1
   destination:
     server: https://kubernetes.default.svc
     namespace: elastic-system

--- a/platform-applications/metrics-server.yaml
+++ b/platform-applications/metrics-server.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: metrics-server
     repoURL: https://kubernetes-sigs.github.io/metrics-server/
-    targetRevision: 3.12.2 # metrics-server v0.7.2
+    targetRevision: 3.13.1 # metrics-server v0.8.1
     helm:
       parameters:
         - name: replicas

--- a/platform-applications/reloader.yaml
+++ b/platform-applications/reloader.yaml
@@ -10,7 +10,7 @@ spec:
     repoURL: https://stakater.github.io/stakater-charts
     # Chart versions at https://artifacthub.io/packages/helm/stakater/reloader
     # Changelog at https://github.com/stakater/Reloader/releases
-    targetRevision: 2.1.3 # app version 1.4.2
+    targetRevision: 2.2.14 # app version 1.4.19
   destination:
     server: https://kubernetes.default.svc
     namespace: reloader

--- a/platform-applications/sealed-secrets.yaml
+++ b/platform-applications/sealed-secrets.yaml
@@ -9,7 +9,7 @@ spec:
     chart: sealed-secrets
     repoURL: https://bitnami.github.io/sealed-secrets
     # Changelog at https://github.com/bitnami-labs/sealed-secrets/blob/main/RELEASE-NOTES.md
-    targetRevision: 2.15.4 # sealed-secrets v0.26.3
+    targetRevision: 2.19.1 # sealed-secrets v0.38.4
     helm:
       parameters:
         # Fix helm chart compatibility with kubeseal

--- a/platform/argocd/kustomization.yaml
+++ b/platform/argocd/kustomization.yaml
@@ -1,7 +1,7 @@
 namespace: argocd
 resources:
   - ./namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.1.7/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.5/manifests/install.yaml
 
 # NOTE: patchesStrategicMerge is deprecated but still works. Converting to the suggested
 # patches: { file: ./config.yaml } syntax results in a validation error.

--- a/platform/kube-prometheus-stack/kustomization.yaml
+++ b/platform/kube-prometheus-stack/kustomization.yaml
@@ -9,7 +9,7 @@ helmCharts:
     # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
     # Version changelogs at:
     # https://github.com/prometheus-community/helm-charts/releases
-    version: 74.0.0 # operator version 0.83.0 / prometheus version 3.4.1 / grafana version 12.0.1
+    version: 87.17.0 # operator version 0.92.1
     namespace: monitoring
     includeCRDs: true
     valuesInline:

--- a/platform/logging/clickhouse.yaml
+++ b/platform/logging/clickhouse.yaml
@@ -29,6 +29,10 @@ spec:
     podTemplates:
       - name: pod-template
         spec:
+          containers:
+            - name: clickhouse
+              # Pin explicitly: without this the operator deploys clickhouse-server:latest
+              image: clickhouse/clickhouse-server:26.6
           tolerations:
             - key: role
               value: database

--- a/platform/logging/gigapipe.yaml
+++ b/platform/logging/gigapipe.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: ghcr.io/metrico/gigapipe:v4.1.0
+          image: ghcr.io/metrico/gigapipe:v4.3.1
           ports:
             - containerPort: 3100
           resources:


### PR DESCRIPTION
Second upgrade batch from automated test run `36df1f`, each change synced in-place on a live 7-node cluster running the full platform + rails-example, and verified individually. Post-batch state: all 18 ArgoCD apps Synced/Healthy, end-to-end app checks green.

## Version bumps

| Component | From | To |
|---|---|---|
| reloader | 2.1.3 (1.4.2) | 2.2.14 (1.4.19) |
| metrics-server | 3.12.2 (0.7.2) | 3.13.1 (0.8.1) |
| sealed-secrets | 2.15.4 (0.26.3) | 2.19.1 (0.38.4) |
| cert-manager | 1.18.0 | 1.21.0 |
| altinity-clickhouse-operator | 0.24.0 | 0.27.1 |
| ClickHouse (gigapipe) | `:latest` (unpinned!) | `26.6` pinned |
| gigapipe | v4.1.0 | v4.3.1 |
| kube-prometheus-stack | 74.0.0 | 87.17.0 (prometheus 3.13.1) |
| eck-operator | 3.0.0 | 3.4.1 |
| ArgoCD | v3.1.7 | v3.4.5 |

## Notable fixes beyond the bumps

- **altinity: hook-based CRD install disabled** (`crdHook.enabled: false`). The 0.25+ chart ships CRDs in PreSync hook ConfigMaps that exceed the 262KB last-applied annotation limit, and ArgoCD applies hooks client-side even with app-level ServerSideApply — the sync wedges on "waiting for completion of hook". CRDs are already rendered and managed via `helm template --include-crds`, so the hook is redundant under gitops. Also added `ServerSideApply=true` to the app and removed the stale "not upgrading until #1714" note (fixed upstream in 0.25.1).
- **argocd: `ServerSideApply=true`** — the ApplicationSet CRD also exceeds the annotation limit, which breaks self-managed ArgoCD upgrades under client-side apply.
- **ClickHouse pinned** — without an explicit image the altinity operator deploys `clickhouse-server:latest`, an unpinned moving target for a database.

## Verification highlights

- sealed-secrets 0.26 → 0.38: existing sealed secrets still decrypt; fresh seal/unseal roundtrip verified.
- kube-prometheus-stack (13 chart majors in one jump): applied in a single sync thanks to ServerSideApply; 44 scrape targets up, Grafana serving through the tunnel.
- ECK 3.0 → 3.4.1: operator rolled in ~30s, Elasticsearch cluster green throughout, search e2e passing.
- ArgoCD self-upgrade: all six deployments rolled to v3.4.5, UI reachable, sync machinery verified post-upgrade.
- Logging pipeline (promtail → gigapipe v4.3.1 → ClickHouse 26.6): label + LogQL range queries returning data after the upgrades. Note: single-replica ClickHouse restarts cause a brief (<30s, self-healing) ingestion gap.

Full learnings in `agent/VERIFICATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)