### PR TITLE
Mechanical upgrades: cloudflared, promtail, local-path-provisioner, local Talos flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ If you already have an empty Kubernetes cluster ready you can skip this part. Bu
 - Docker (eg. via [Docker Desktop](https://www.docker.com/products/docker-desktop/))
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 - [yq](https://github.com/mikefarah/yq#install)
-- [talosctl](https://www.talos.dev/v1.6/introduction/getting-started/#talosctl)
+- [talosctl](https://www.talos.dev/v1.13/introduction/getting-started/#talosctl)
 
 Now bootstrap a local Docker based Talos cluster with:
 
 ```
-talosctl cluster create \
+talosctl cluster create docker \
   --name reclaim-the-stack \
-  --image ghcr.io/siderolabs/talos:v1.6.7 \
-  --kubernetes-version 1.29.2 \
+  --image ghcr.io/siderolabs/talos:v1.13.6 \
+  --kubernetes-version 1.36.2 \
   --workers 1 \
-  --cpus "2.0" \
+  --cpus-controlplanes "2.0" \
   --cpus-workers "4.0" \
-  --memory 2048 \
-  --memory-workers 4096 \
-  --config-patch-worker @platform/talos-worker-patch.yaml
+  --memory-controlplanes 2GiB \
+  --memory-workers 4GiB \
+  --config-patch-workers @platform/talos-worker-patch.yaml
 ```
 
 When your cluster is up and running you can configure `kubectl` and `talosctl` to use it by:

--- a/agent/VERIFICATION.md
+++ b/agent/VERIFICATION.md
@@ -5,6 +5,12 @@ covers. Append to this file when a run teaches you something the checks missed.
 
 ## Run 36df1f upgrade batch 2 (2026-07-20, nine components)
 
+- **talosctl 1.13 restructured `cluster create`** into provisioner
+  subcommands (`talosctl cluster create docker`) and renamed flags
+  (--cpus-controlplanes, --memory-controlplanes with GiB format,
+  --config-patch-workers). The v1.6-era README syntax prints usage help and
+  exits 0 -- validate README commands by running them, not by exit codes.
+
 - **altinity-clickhouse-operator chart 0.25+ CRD hooks break under ArgoCD.**
   The chart installs CRDs via PreSync hook ConfigMaps + a job; ArgoCD applies
   hooks client-side (app-level ServerSideApply does NOT cover hooks) and the

--- a/platform/cloudflared/Chart.yaml
+++ b/platform/cloudflared/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: cloudflared
-version: 2025.4.0
+version: 2026.7.2

--- a/platform/local-path-provisioner/README.md
+++ b/platform/local-path-provisioner/README.md
@@ -1,5 +1,5 @@
 Original source:
-https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.27/deploy/local-path-storage.yaml
+https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.36/deploy/local-path-storage.yaml
 
 ## Changes
 

--- a/platform/local-path-provisioner/local-path-storage.yaml
+++ b/platform/local-path-provisioner/local-path-storage.yaml
@@ -92,7 +92,7 @@ spec:
       serviceAccountName: local-path-provisioner-service-account
       containers:
         - name: local-path-provisioner
-          image: rancher/local-path-provisioner:v0.0.27
+          image: docker.io/rancher/local-path-provisioner:v0.0.36
           imagePullPolicy: IfNotPresent
           command:
             - local-path-provisioner
@@ -163,5 +163,5 @@ data:
           effect: NoSchedule
       containers:
       - name: helper-pod
-        image: busybox
+        image: docker.io/library/busybox
         imagePullPolicy: IfNotPresent

--- a/platform/logging/kustomization.yaml
+++ b/platform/logging/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: promtail
     repo: https://grafana.github.io/helm-charts
     # Changelog at https://github.com/grafana/loki/blob/main/CHANGELOG.md
-    version: 6.17.0 # app version 3.5.1
+    version: 6.17.1 # app version 3.5.1
     releaseName: promtail # without this pods are named release-name
     namespace: logging
     valuesInline:


### PR DESCRIPTION
Follow-up batch of low-risk upgrades from test run `36df1f`, plus a validated refresh of the local Talos bootstrap docs.

## Changes

| Component | From | To | Verified |
|---|---|---|---|
| cloudflared | 2025.4.0 | 2026.7.2 | tunnel pod rolled, ingress smoke test green |
| promtail | 6.17.0 | 6.17.1 | log streams flowing post-roll |
| local-path-provisioner | v0.0.27 | v0.0.36 | re-vendored with documented modifications reapplied; app Synced/Healthy |
| Local Talos flow (README) | v1.6.7 / k8s 1.29.2 | v1.13.6 / k8s 1.36.2 | full README flow executed locally: create, context setup, labeling, teardown |

## README fix worth noting

`talosctl` 1.13 restructured `cluster create` into provisioner subcommands and renamed flags — the old README command now just prints usage help (exit 0!). Updated to:

```
talosctl cluster create docker \
  --cpus-controlplanes "2.0" \
  --memory-controlplanes 2GiB \
  --memory-workers 4GiB \
  --config-patch-workers @platform/talos-worker-patch.yaml \
  ...
```

Kubernetes 1.36.2 matches both the Talos v1.13.6 default and the k3s version in the Hetzner config, so local and cloud clusters now run the same Kubernetes version.

Note: promtail is deprecated upstream in favor of Grafana Alloy — this bump is maintenance-only while a log-collector migration is considered separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)