### PR TITLE
Migrate linkerd from stable-2.14.10 to edge-26.5.1 with native sidecars

### DIFF
--- a/agent/VERIFICATION.md
+++ b/agent/VERIFICATION.md
@@ -3,6 +3,20 @@
 Checks and pitfalls discovered during test runs, beyond what smoke-test.sh
 covers. Append to this file when a run teaches you something the checks missed.
 
+## Run 36df1f linkerd migration (2026-07-20, stable-2.14.10 -> edge-26.5.1)
+
+- **The linkerd OSS stable channel is dead** — stable-2.14 was the last;
+  open source releases now ship on the edge channel only (helm repo
+  https://helm.linkerd.io/edge). Use releases marked "recommended" in the
+  GitHub release notes, per Mynewsdesk operational practice.
+- The 2.14 -> 26.5.1 jump synced cleanly in one step on a live mesh; meshed
+  workloads kept serving on old proxies until restarted (README process:
+  control plane, then viz, then rollout-restart all meshed workloads).
+  Meshed pods are found by looking for a linkerd-proxy container OR
+  initContainer (native sidecar mode moves it to initContainers).
+- installGatewayAPI defaults to false in current edge charts — no Gateway
+  API CRDs are required unless HTTPRoute policy is wanted.
+
 ## Run 36df1f upgrade batch 2 (2026-07-20, nine components)
 
 - **talosctl 1.13 restructured `cluster create`** into provisioner

--- a/platform/linkerd-viz/kustomization.yaml
+++ b/platform/linkerd-viz/kustomization.yaml
@@ -4,9 +4,9 @@ resources:
   - ./webhook-issuer-secret.yaml
 helmCharts:
   - name: linkerd-viz
-    repo: https://helm.linkerd.io/stable
+    repo: https://helm.linkerd.io/edge
     releaseName: linkerd-viz
-    version: 30.12.11 # Linkerd version 2.14.10
+    version: 2026.5.1 # linkerd edge-26.5.1
     namespace: linkerd-viz
     valuesInline:
       tap:

--- a/platform/linkerd/kustomization.yaml
+++ b/platform/linkerd/kustomization.yaml
@@ -4,14 +4,18 @@ resources:
   - ./webhook-issuer-secret.yaml
 helmCharts:
   - name: linkerd-crds
-    repo: https://helm.linkerd.io/stable
+    repo: https://helm.linkerd.io/edge
     releaseName: linkerd-crds
-    version: 1.8.0
+    version: 2026.5.1 # linkerd edge-26.5.1
     namespace: linkerd
+    valuesInline:
+      # Default is false; set to true if you want Linkerd to manage the
+      # Gateway API CRDs (needed for HTTPRoute based policy)
+      installGatewayAPI: false
   - name: linkerd-control-plane
-    repo: https://helm.linkerd.io/stable
+    repo: https://helm.linkerd.io/edge
     releaseName: linkerd
-    version: 1.16.11 # Linkerd version 2.14.10
+    version: 2026.5.1 # linkerd edge-26.5.1
     namespace: linkerd
     valuesInline:
       proxyInit:
@@ -86,6 +90,7 @@ helmCharts:
           maxSurge: 25%
       enablePodAntiAffinity: true
       proxy:
+        nativeSidecar: true # run the proxy as a native sidecar container (requires Kubernetes 1.29+)
         resources:
           cpu:
             request: 100m


### PR DESCRIPTION
Migrates the service mesh off the dead OSS stable channel, adapted from the Mynewsdesk production migration of the same setup and validated on live test cluster `36df1f`.

## Background

The open source `stable` Helm channel ended with 2.14 — stable releases moved to Buoyant Enterprise, and OSS Linkerd now ships via the `edge` channel. stable-2.14.10 (early 2024) no longer receives security patches. Per operational practice at Mynewsdesk: only use edge releases marked **recommended** in the release notes; edge-26.5.1 is the latest such release.

## Changes

- `linkerd-crds` 1.8.0 → 2026.5.1, `linkerd-control-plane` 1.16.11 → 2026.5.1, `linkerd-viz` 30.12.11 → 2026.5.1, all switched to `https://helm.linkerd.io/edge`
- **Native sidecar mode enabled** (`proxy.nativeSidecar: true`, requires Kubernetes 1.29+): the proxy runs as a native sidecar initContainer, fixing container startup ordering and meshed Jobs never completing
- `installGatewayAPI: false` made explicit on linkerd-crds (the current chart default) with a comment — no Gateway API CRDs required unless HTTPRoute-based policy is wanted
- Existing trust anchor / issuer certificates and all other values carried over unchanged

## Verification on the live cluster

- Control plane synced 2.14.10 → edge-26.5.1 in one step; meshed workloads (cloudflared, rails-example web/sidekiq, grafana) kept serving on old proxies until restarted
- Post-restart: all meshed pods on edge-26.5.1 proxies as native sidecars (`initContainers: linkerd-init, linkerd-proxy`)
- All 18 ArgoCD apps Synced/Healthy; end-to-end app checks green (Postgres, Redis+Sidekiq, Elasticsearch) through the meshed data path; ingress smoke test green through the meshed cloudflared

Upgrade process notes captured in `agent/VERIFICATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)