### PR TITLE
Upgrade elasticsearch generator to 7.17.29 (latest 7.x)

### DIFF
--- a/generators/resources/elasticsearch.yaml
+++ b/generators/resources/elasticsearch.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   # NOTE: we default to 7.x to allow compatibility with OpenSearch, but feel free to use 8.x
   # When changing the version here, also make the correspoding change to the Kibana instance.
-  version: 7.17.25
+  version: 7.17.29
   # Add an S3 credentials secret and uncomment this to enable S3 based snapshots via Kibana
   # secureSettings:
   #   - secretName: elasticsearch-s3-credentials
@@ -122,7 +122,7 @@ kind: Kibana
 metadata:
   name: {{ .Chart.Name }}%{suffix}
 spec:
-  version: 7.17.25
+  version: 7.17.29
   count: 1
   http:
     tls:

--- a/generators/resources/elasticsearch.yaml
+++ b/generators/resources/elasticsearch.yaml
@@ -19,8 +19,8 @@ kind: Elasticsearch
 metadata:
   name: {{ .Chart.Name }}%{suffix}
 spec:
-  # NOTE: we default to 7.x to allow compatibility with OpenSearch, but feel free to use 8.x
-  # When changing the version here, also make the correspoding change to the Kibana instance.
+  # NOTE: we default to 7.x to allow compatibility with OpenSearch, but feel free to use later major versions
+  # When changing the version here, also make the corresponding change to the Kibana instance.
   version: 7.17.29
   # Add an S3 credentials secret and uncomment this to enable S3 based snapshots via Kibana
   # secureSettings:


### PR DESCRIPTION
Bumps the Elasticsearch generator (ES + Kibana) from 7.17.25 to 7.17.29 — the latest 7.x release — staying on the 7.x line for OpenSearch compatibility per the existing template note.

Verified on live test cluster `36df1f`: ECK performed the rolling upgrade across the 2-node + tiebreaker cluster with health green throughout (~2 minutes), Kibana upgraded alongside, and the application's search functionality verified end-to-end afterwards.

Note for existing deployments: as with all generator changes, already-generated `applications/<app>/templates/elasticsearch.yaml` files carry their own version pin and need the same one-line bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)