### PR TITLE
Replace promtail with vector for pod log collection

### DIFF
--- a/agent/VERIFICATION.md
+++ b/agent/VERIFICATION.md
@@ -14,10 +14,12 @@ covers. Append to this file when a run teaches you something the checks missed.
   if-null fallbacks), and dynamic "*" label maps need
   dangerously_allow_unconfined_template_resolution: true on the loki sink.
   Disable the sink healthcheck -- gigapipe has no /ready endpoint.
-- **Gigapipe has ~1-2 min ingest visibility lag** (ClickHouse insert
-  buffering): query_range returns nothing for very fresh lines while
-  /series and /labels already show them. Wait before concluding the
-  pipeline is broken.
+- **Gigapipe is near-realtime in steady state** (~3s write-to-queryable,
+  measured with a marker line; flush default BULK_MAX_AGE_MS=100).
+  However, immediately after a collector cutover -- when every stream
+  fingerprint is new -- query_range lagged /series by a couple of minutes
+  before converging. Treat brief post-cutover blindness as transient:
+  verify with a marker line and a poll loop, not a single query.
 - Footprint: ~15m CPU / ~196Mi RAM total across 7 vector agents.
 
 ## Run 36df1f linkerd migration (2026-07-20, stable-2.14.10 -> edge-26.5.1)

--- a/agent/VERIFICATION.md
+++ b/agent/VERIFICATION.md
@@ -3,6 +3,23 @@
 Checks and pitfalls discovered during test runs, beyond what smoke-test.sh
 covers. Append to this file when a run teaches you something the checks missed.
 
+## Run 36df1f promtail -> vector migration (2026-07-20)
+
+- Label parity verified exactly: a VRL remap reproduces promtail's scheme
+  (app/component from pod labels with app.kubernetes.io/* fallbacks,
+  job=namespace/app, instance, container, filename, namespace, node_name,
+  pod, stream). Verified by diffing /loki/api/v1/labels and per-pod
+  /series output before and after cutover -- identical.
+- vector 0.57 gotchas: VRL rejects ?? on infallible path lookups (use
+  if-null fallbacks), and dynamic "*" label maps need
+  dangerously_allow_unconfined_template_resolution: true on the loki sink.
+  Disable the sink healthcheck -- gigapipe has no /ready endpoint.
+- **Gigapipe has ~1-2 min ingest visibility lag** (ClickHouse insert
+  buffering): query_range returns nothing for very fresh lines while
+  /series and /labels already show them. Wait before concluding the
+  pipeline is broken.
+- Footprint: ~15m CPU / ~196Mi RAM total across 7 vector agents.
+
 ## Run 36df1f linkerd migration (2026-07-20, stable-2.14.10 -> edge-26.5.1)
 
 - **The linkerd OSS stable channel is dead** — stable-2.14 was the last;

--- a/platform/logging/kustomization.yaml
+++ b/platform/logging/kustomization.yaml
@@ -4,24 +4,79 @@ resources:
   - ./gigapipe.yaml
 namespace: logging
 helmCharts:
-  # Promtail captures logs from all Kubernetes pods and pushes them in batches to Gigapipe
-  - name: promtail
-    repo: https://grafana.github.io/helm-charts
-    # Changelog at https://github.com/grafana/loki/blob/main/CHANGELOG.md
-    version: 6.17.1 # app version 3.5.1
-    releaseName: promtail # without this pods are named release-name
+  # Vector captures logs from all Kubernetes pods and pushes them to Gigapipe.
+  # It replaces the deprecated Promtail (EOL 2026) and emits the same log
+  # labels Promtail used to, so existing queries and dashboards keep working.
+  - name: vector
+    repo: https://helm.vector.dev
+    releaseName: vector # without this pods are named release-name
+    # Changelogs at https://vector.dev/releases/
+    version: 0.57.0 # vector version 0.57.0
     namespace: logging
     valuesInline:
+      role: "Agent"
+      service:
+        enabled: false
       tolerations:
         - effect: NoSchedule
           operator: Exists
         - effect: NoExecute
           operator: Exists
-      config:
-        clients:
-          - url: http://gigapipe.logging.svc.cluster.local:3100/loki/api/v1/push
+      customConfig:
+        data_dir: /vector-data-dir
+        sources:
+          kubernetes_logs:
+            type: kubernetes_logs
+        transforms:
+          kubernetes_logs_labelled:
+            type: remap
+            inputs:
+              - kubernetes_logs
+            # Reproduce the labels Promtail used to emit: app/component from
+            # pod labels (with app.kubernetes.io/* fallbacks), job as
+            # <namespace>/<app>, instance from app.kubernetes.io/instance
+            source: |
+              .labels = {
+                "namespace": .kubernetes.pod_namespace,
+                "pod": .kubernetes.pod_name,
+                "container": .kubernetes.container_name,
+                "node_name": .kubernetes.pod_node_name,
+                "filename": .file,
+                "stream": .stream,
+                "job": .kubernetes.pod_namespace
+              }
+              app = .kubernetes.pod_labels.app
+              if app == null { app = .kubernetes.pod_labels."app.kubernetes.io/name" }
+              if app != null {
+                .labels.app = app
+                .labels.job = string!(.kubernetes.pod_namespace) + "/" + string!(app)
+              }
+              component = .kubernetes.pod_labels.component
+              if component == null { component = .kubernetes.pod_labels."app.kubernetes.io/component" }
+              if component != null { .labels.component = component }
+              instance = .kubernetes.pod_labels."app.kubernetes.io/instance"
+              if instance != null { .labels.instance = instance }
+        sinks:
+          gigapipe:
+            type: loki
+            inputs:
+              - kubernetes_logs_labelled
+            endpoint: http://gigapipe.logging.svc.cluster.local:3100
+            encoding:
+              codec: text
+            out_of_order_action: accept
+            healthcheck:
+              enabled: false # gigapipe does not implement the loki /ready endpoint
+            # Required for the dynamic "*" label map below
+            dangerously_allow_unconfined_template_resolution: true
+            labels:
+              "*": |-
+                {{`{{ labels }}`}}
 
-  # Talos Linux host OS logs
+  # Talos Linux host OS logs can be shipped by adding the following sources /
+  # transforms / sinks to the vector customConfig above (requires
+  # podHostNetwork: true and the talos machine config to forward logs, see
+  # https://www.talos.dev/latest/talos-guides/configuration/logging/)
   # - name: vector
   #   repo: https://helm.vector.dev
   #   releaseName: vector


### PR DESCRIPTION
Migrates pod log collection off the EOL promtail onto vector 0.57, validated on live test cluster `36df1f` with an exact label-parity check.

## Why vector (over Grafana Alloy)

- Promtail is deprecated/EOL; Alloy is Grafana's official successor but is a heavyweight general-purpose collector and re-buys the vendor-consolidation risk that killed promtail
- Vector is lighter for DaemonSet log-shipping duty (measured: ~15m CPU / ~196Mi RAM total across 7 agents), pairs well with Gigapipe/ClickHouse, and can additionally ship Talos host OS logs — consolidating log collection into one agent (the Talos config remains as a documented comment block)

## Label parity

A VRL remap reproduces promtail's exact label scheme: `app`/`component` from pod labels with `app.kubernetes.io/*` fallbacks, `job` = `namespace/app`, `instance` from `app.kubernetes.io/instance`, plus `container`, `filename`, `namespace`, `node_name`, `pod`, `stream`. Verified by diffing `/loki/api/v1/labels` and per-pod `/series` output before and after cutover — **identical**, so existing queries and dashboards keep working.

## Verification

- All 7 vector agents healthy, 100% of pushes accepted by gigapipe (204s)
- Deliberately generated request logs queryable end-to-end via LogQL line filters
- Steady-state ingest is near-realtime (~3s write-to-queryable measured with a marker line; gigapipe flushes to ClickHouse every `BULK_MAX_AGE_MS`=100ms by default). One transient discovered (documented in VERIFICATION.md): immediately after a collector cutover, when every stream fingerprint is new, `query_range` lagged `/series` by a couple of minutes before converging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
